### PR TITLE
Update core.py for numbered_list_pattern_nested and unordered_list_pattern_nested block and convert_markdown_table_to_notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ You can create a blockquote using `>`:
 
 You can create tables with or without header rows. They will become LaTeX/KaTeX tables or Notion tables in the Notion page.
 
-A switch parameter is_latex_table added to parse_md and create_notion_page_from_md functions in core.py. The default is_latex_table=True, and the original call is not affected.
+A switch parameter is_latex_table added to parse_md and create_notion_page_from_md functions in core.py. 
+
+The default is_latex_table=True, and the original call is not affected.
 
 ### Table with Headers
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ parent_page_id = 'YOUR_PARENT_PAGE_ID'
 
 notion_page_url = md2notionpage(markdown_text, title, parent_page_id)
 ```
- Or calling the core function of convert markdown to notion blocks in your own function, and implement the logic of other notation operations yourself
+ Or calling the core function of convert markdown to notion blocks in your own function, and implement the logic of other notation operations yourself:
  ```python
 from notion_client import Client as Notion
 from md2notionpage import md2notion_parse_md
@@ -38,7 +38,8 @@ def create_page(title, industry, language, date_str, md_content=None):
 
 	notion = Notion(auth=NOTION_API_KEY, notion_version=NOTION_VERSION) # Define your env parameters
 
-	children = md2notion_parse_md(md_content, is_latex_table=False) if md_content else [] # is_latex_table = False means Markdown Table concerted to Notion Table instead of LaTeX Table
+	# is_latex_table = False means Markdown Table concerted to Notion Table instead of LaTeX Table
+	children = md2notion_parse_md(md_content, is_latex_table=False) if md_content else []
 
 	properties = {
 		 "Name": {"title": [{"type": "text", "text": {"content": title}}]},
@@ -46,11 +47,11 @@ def create_page(title, industry, language, date_str, md_content=None):
 		 "Language": {"rich_text": [{"type": "text", "text": {"content": language}}]},
 		 "Create Date": {"rich_text": [{"type": "text", "text": {"content": date_str + "UTC"}}]}
 	} 
-	 resp = notion.pages.create(
+	resp = notion.pages.create(
 	 	parent={"database_id": NOTION_DATABASE_ID},
 	 	properties=properties,
 	 	children=children
-	 )
+	)
 ```
 # Supported Markdown Features
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # md2notionpage
 
-A Python package to convert Markdown text into Notion pages. This module provides functionality to create Notion pages from Markdown text, parse Markdown into Notion blocks, and process inline formatting.
+A Python package to convert Markdown text into Notion Blocks pages. This module provides functionality to create Notion pages from Markdown text, parse Markdown into Notion blocks, and process inline formatting.
 
 ## Installation
 
@@ -29,7 +29,29 @@ parent_page_id = 'YOUR_PARENT_PAGE_ID'
 
 notion_page_url = md2notionpage(markdown_text, title, parent_page_id)
 ```
+ Or calling the core function of convert markdown to notion blocks in your own function, and implement the logic of other notation operations yourself
+ ```python
+from notion_client import Client as Notion
+from md2notionpage import md2notion_parse_md
 
+def create_page(title, industry, language, date_str, md_content=None):
+
+	notion = Notion(auth=NOTION_API_KEY, notion_version=NOTION_VERSION) # Define your env parameters
+
+	children = md2notion_parse_md(md_content, is_latex_table=False) if md_content else [] # is_latex_table = False means Markdown Table concerted to Notion Table instead of LaTeX Table
+
+	properties = {
+		 "Name": {"title": [{"type": "text", "text": {"content": title}}]},
+		 "Industry": {"rich_text": [{"type": "text", "text": {"content": industry}}]},
+		 "Language": {"rich_text": [{"type": "text", "text": {"content": language}}]},
+		 "Create Date": {"rich_text": [{"type": "text", "text": {"content": date_str + "UTC"}}]}
+	} 
+	 resp = notion.pages.create(
+	 	parent={"database_id": NOTION_DATABASE_ID},
+	 	properties=properties,
+	 	children=children
+	 )
+```
 # Supported Markdown Features
 
 ## Headings
@@ -98,7 +120,8 @@ You can create a blockquote using `>`:
 
 ## Tables
 
-You can create tables with or without header rows. They will become LaTeX/KaTeX tables in the Notion page.
+You can create tables with or without header rows. They will become LaTeX/KaTeX tables or Notion tables in the Notion page.
+A switch parameter is_latex_table added to parse_md and create_notion_page_from_md functions in core.py. The default is_latex_table=True, and the original call is not affected.
 
 ### Table with Headers
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ You can create a blockquote using `>`:
 ## Tables
 
 You can create tables with or without header rows. They will become LaTeX/KaTeX tables or Notion tables in the Notion page.
+
 A switch parameter is_latex_table added to parse_md and create_notion_page_from_md functions in core.py. The default is_latex_table=True, and the original call is not affected.
 
 ### Table with Headers

--- a/md2notionpage/__init__.py
+++ b/md2notionpage/__init__.py
@@ -1,1 +1,2 @@
 from .core import create_notion_page_from_md as md2notionpage
+from .core import parse_md as md2notion_parse_md

--- a/md2notionpage/core.py
+++ b/md2notionpage/core.py
@@ -567,7 +567,21 @@ def parse_markdown_to_notion_blocks(markdown):
                 "rich_text": [{"type": "text", "text": {"content": code_block}}]
             }
         })
-
+    # Final cleanup step: Remove all top-level 'indent' properties before returning
+    def _clean_blocks(blocks):
+        """Recursively removes the top-level 'indent' property from all blocks and their children."""
+        for block in blocks:
+            if 'indent' in block:
+                del block['indent']
+                
+            # Check for nested children (e.g., within paragraph or list_item content)
+            block_type = block.get('type')
+            if block_type and block_type in block:
+                content = block[block_type]
+                if 'children' in content and isinstance(content['children'], list):
+                    _clean_blocks(content['children'])
+        return blocks
+    blocks = _clean_blocks(blocks)
     return blocks
 
 def parse_md(markdown_text):

--- a/md2notionpage/core.py
+++ b/md2notionpage/core.py
@@ -340,13 +340,13 @@ def parse_markdown_to_notion_blocks(markdown):
         list_match = re.match(numbered_list_pattern_nested, line)
         if list_match:
             indent = len(list_match.group(1))
-            line_content = line[len(list_match.group(0)):]
+            line = line[len(list_match.group(0)):]
 
             item = {
                 "object": "block",
                 "type": "numbered_list_item",
                 "numbered_list_item": {
-                    "rich_text": process_inline_formatting(line_content)
+                    "rich_text": process_inline_formatting(line)
                 },
                 # Explicitly save indent for finding the new current_indent upon dedentation (pop)
                 'indent': indent 
@@ -381,7 +381,7 @@ def parse_markdown_to_notion_blocks(markdown):
                     current_indent = indent
                 else:
                     # This indicates the top Block on the stack is invalid or malformed.
-                    print(f"Warning: Invalid top Block structure ({current_block}: {line_content}). Cannot nest. Falling back to sibling.")
+                    print(f"Warning: Invalid top Block structure ({current_block}: {line}). Cannot nest. Falling back to sibling.")
                     stack[-1].append(item) 
             continue
 
@@ -389,13 +389,13 @@ def parse_markdown_to_notion_blocks(markdown):
         list_match = re.match(unordered_list_pattern_nested, line)
         if list_match:
             indent = len(list_match.group(1))
-            line_content = line[len(list_match.group(0)):]
+            line = line[len(list_match.group(0)):]
 
             item = {
                 "object": "block",
                 "type": "bulleted_list_item",
                 "bulleted_list_item": {
-                    "rich_text": process_inline_formatting(line_content)
+                    "rich_text": process_inline_formatting(line)
                 },
                 # Explicitly save indent for finding the new current_indent upon dedentation (pop)
                 'indent': indent 
@@ -430,7 +430,7 @@ def parse_markdown_to_notion_blocks(markdown):
                     current_indent = indent
                 else:
                     # This indicates the top Block on the stack is invalid or malformed.
-                    print(f"Warning: Invalid top Block structure ({current_block}: {line_content}). Cannot nest. Falling back to sibling.")
+                    print(f"Warning: Invalid top Block structure ({current_block}: {line}). Cannot nest. Falling back to sibling.")
                     stack[-1].append(item) 
             continue
 


### PR DESCRIPTION
feat: Implement full support for nested bulleted , numbered lists and MD table to notion table feature.

This commit refactors the list parsing logic to correctly handle multi-level (nested) lists based on indentation. 

The primary change involves:
1.  **Stack Management:** Using a stack to track the current parent block and its indentation level (`current_indent`).
2.  **Nesting Logic:** Appending new, more-indented list items to the `children` array of the previous block, and pushing that `children` array onto the stack.
3.  **Dedenting (Pop):** Popping items from the stack when a line's indentation decreases, effectively closing a nested list block and returning to a higher parent level.
4. **Markdown Table to Notion Table:** Implemented the function of converting Mardown Table into Notion Table, and added a switch parameter to parse_md and create_notion_page_from_md functions. The default is_latex_table=True, and the original call is not affected.
5. **Update README.md and __init__.py** 

This resolves the issue where only flat lists were supported and ensures the JSON output accurately reflects the nested structure of the input Markdown/text.